### PR TITLE
Set order of payments to actives first.

### DIFF
--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -203,7 +203,8 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
     {
         $builder = Shopware()->Models()->createQueryBuilder();
         $builder->select(['payment'])
-            ->from(Payment::class, 'payment');
+            ->from(Payment::class, 'payment')
+            ->orderBy("payment.active","DESC");
 
         $paymentMethods = $builder->getQuery()->getArrayResult();
 


### PR DESCRIPTION
Dropdown shows every payment method available.
For improved usability the active ones are shown first.