### PR TITLE
Keep backend customer details window fully extensible

### DIFF
--- a/Resources/views/backend/customer/controller/create_backend_order/main.js
+++ b/Resources/views/backend/customer/controller/create_backend_order/main.js
@@ -99,6 +99,8 @@ Ext.define('Shopware.apps.CreateBackendOrder.controller.Main', {
                 listStore: me.subApplication.getStore('List').load()
             });
         }
+
+        this.callParent(arguments);
     }
 
 });

--- a/Resources/views/backend/customer/view/create_backend_order/detail/additional.js
+++ b/Resources/views/backend/customer/view/create_backend_order/detail/additional.js
@@ -4,53 +4,27 @@ Ext.define('Shopware.apps.CreateBackendOrder..view.detail.Additional', {
     override: 'Shopware.apps.Customer.view.detail.Additional',
 
     /**
-     * Creates the container for the "Perform order" button which
-     * is displayed on bottom of the panel.
-     * @return { Ext.container.Container } - Contains the perform order button and the create account button when the accountMode of the customer is set to 1
+     * Adds the "perform backend order" button to the buttons container.
+     *
+     * @return { Ext.container.Container }
      */
-    createButtonsContainer: function () {
-        var me = this,
-            buttons = [];
+    createButtonsContainer: function() {
+        var me = this;
+        var container = this.callParent(arguments);
 
-        /*{if {acl_is_allowed privilege=perform_order}}*/
-        me.performOrderBtn = Ext.create('Ext.button.Button', {
-            text: me.snippets.performOrderBtn,
-            handler: function () {
-                me.fireEvent('performOrder', me.record);
-            }
-        });
-        buttons.push(me.performOrderBtn);
+        // Reset container height to "auto-mode"
+        delete container.height;
 
-        me.performBackendOrderBtn = Ext.create('Ext.button.Button', {
+        // Add "perform backend order" button to container
+        container.add(Ext.create('Ext.button.Button', {
+            margin: '5 0 0 0',
             text: '{s namespace="backend/customer/view/main" name="swag_backend_order/customer/additional/create_backend_order"}Create order in the backend{/s}',
             handler: function () {
                 me.fireEvent('performBackendOrder', me.record);
             }
-        });
-        buttons.push(me.performBackendOrderBtn);
-        /*{/if}*/
+        }));
 
-        /*{if {acl_is_allowed privilege=update}}*/
-        if (me.record.get('accountMode') == 1) {
-            me.createAccountButton = Ext.create('Ext.button.Button', {
-                text: me.snippets.createAccountBtn,
-                handler: function () {
-                    var tpl = me.createInfoPanelTemplate();
-                    me.fireEvent('createAccount', me.record, me.infoView, tpl, me.createAccountButton);
-                }
-            });
-            buttons.push(me.createAccountButton);
-        }
-        /*{/if}*/
-
-        return Ext.create('Ext.container.Container', {
-            height: 85,
-            defaults: {
-                margin: '5 0 0 0'
-            },
-            cls: Ext.baseCSSPrefix + 'button-container',
-            items: buttons
-        });
+        return container;
     }
 });
 //{/block}


### PR DESCRIPTION
The current implementation adds functionality to the backend's customer details window by overriding various methods of the default classes. Unfortunately this is done in a matter, which prevents other plugins from extending these parts as well. This pull requests fixes these issues.
