### PR TITLE
Fix order details tax for taxfree orders

### DIFF
--- a/Components/Order/Factory/DetailFactory.php
+++ b/Components/Order/Factory/DetailFactory.php
@@ -56,11 +56,12 @@ class DetailFactory
 
 
         $tax = $this->modelManager->find(Tax::class, $positionStruct->getTaxId());
-        $detail->setTax($tax);
-        $detail->setTaxRate($tax->getTax());
-        if ($isTaxFree) {
-            $detail->setTaxRate(0);
+        // Actually sOrder::sSaveOrder() sets this to the illegal value of '0' when the order is taxfree,
+        // but this is not possible via Doctrine, so by not setting the value it falls back to NULL
+        if (!$isTaxFree) {
+            $detail->setTax($tax);
         }
+        $detail->setTaxRate($tax->getTax());
 
         $detail->setEsdArticle(0);
 


### PR DESCRIPTION
With this change the creation of orders via the backend is in line with the behavior of the frontend, where `tax_rate` is always set but `taxID` is not for tax free orders. This change does not alter the price calculation at all.

See these `s_order_details` table row examples:
<img width="110" alt="screenshot 2016-10-20 23 31 29" src="https://cloud.githubusercontent.com/assets/710188/19578736/57aa03c2-971d-11e6-8aec-a50eead30437.png">
1. Backend with this PR
2. From frontend
3. Backend without this PR
