### PR TITLE
Fix shipping costs for net and taxfree orders

### DIFF
--- a/Components/Order/Factory/OrderFactory.php
+++ b/Components/Order/Factory/OrderFactory.php
@@ -88,10 +88,6 @@ class OrderFactory
         $order->setInvoiceShippingNet($orderStruct->getShippingCostsNet());
         $order->setInvoiceShipping($orderStruct->getShippingCosts());
 
-        if ($orderStruct->getNetOrder()) {
-            $order->setInvoiceShipping($order->getInvoiceShippingNet());
-        }
-
         $order->setInvoiceAmount($orderStruct->getTotal());
         $order->setInvoiceAmountNet($orderStruct->getTotalWithoutTax());
 

--- a/Components/PriceCalculation/Calculator/ShippingPriceCalculator.php
+++ b/Components/PriceCalculation/Calculator/ShippingPriceCalculator.php
@@ -50,6 +50,11 @@ class ShippingPriceCalculator
 
         $priceStruct->setTaxRate($context->getTaxRate());
 
+        if ($context->isTaxfree()) {
+            $priceStruct->setGross($netPrice);
+            $priceStruct->setTaxRate(0);
+        }
+
         return $priceStruct;
     }
 
@@ -64,7 +69,7 @@ class ShippingPriceCalculator
         );
 
         $basePrice = $baseCurrencyPrice;
-        if ($context->isNetPrice() && $context->getTaxRate() > 0) {
+        if ($context->isTaxfree()) {
             $basePrice = $this->taxCalculation->getGrossPrice($basePrice, $context->getTaxRate());
         }
         return $basePrice;

--- a/Components/PriceCalculation/Calculator/ShippingPriceCalculator.php
+++ b/Components/PriceCalculation/Calculator/ShippingPriceCalculator.php
@@ -60,18 +60,18 @@ class ShippingPriceCalculator
 
     /**
      * @param PriceContext $context
-     * @return float
+     * @return float the base/gross shipping price in the standard currency
      */
     public function calculateBasePrice(PriceContext $context)
     {
-        $baseCurrencyPrice = $this->currencyConverter->getBaseCurrencyPrice(
+        $basePrice = $this->currencyConverter->getBaseCurrencyPrice(
             $context->getPrice(), $context->getCurrencyFactor()
         );
 
-        $basePrice = $baseCurrencyPrice;
         if ($context->isTaxfree()) {
             $basePrice = $this->taxCalculation->getGrossPrice($basePrice, $context->getTaxRate());
         }
+
         return $basePrice;
     }
 }

--- a/Components/PriceCalculation/Context/PriceContext.php
+++ b/Components/PriceCalculation/Context/PriceContext.php
@@ -21,6 +21,11 @@ class PriceContext
     private $netPrice;
 
     /**
+     * @var boolean
+     */
+    private $taxFree;
+
+    /**
      * @var float
      */
     private $currencyFactor;
@@ -34,10 +39,11 @@ class PriceContext
      * @param float $price
      * @param float $taxRate
      * @param boolean $netPrice
+     * @param boolean $taxFree
      * @param float $currencyFactor
      * @throws \Exception
      */
-    public function __construct($price, $taxRate, $netPrice = false, $currencyFactor = 1.0)
+    public function __construct($price, $taxRate, $netPrice = false, $taxFree = false, $currencyFactor = 1.0)
     {
         if (!is_numeric($price)) {
             throw new \Exception("Given price is not numeric.");
@@ -55,6 +61,7 @@ class PriceContext
         $this->taxRate = (float) $taxRate;
         $this->currencyFactor = (float) $currencyFactor;
         $this->netPrice = (boolean) $netPrice;
+        $this->taxFree = (boolean) $taxFree;
     }
 
     /**
@@ -79,6 +86,14 @@ class PriceContext
     public function isNetPrice()
     {
         return $this->netPrice;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isTaxFree()
+    {
+        return $this->taxFree;
     }
 
     /**

--- a/Components/PriceCalculation/Context/PriceContextFactory.php
+++ b/Components/PriceCalculation/Context/PriceContextFactory.php
@@ -29,18 +29,19 @@ class PriceContextFactory
     /**
      * @param float $price
      * @param float $taxRate
+     * @param boolean $taxFree
      * @param boolean $isNetPrice
      * @param int $currencyId
      * @return PriceContext
      */
-    public function create($price, $taxRate, $isNetPrice, $currencyId)
+    public function create($price, $taxRate, $taxFree, $isNetPrice, $currencyId)
     {
         $currency = $this->modelManager->find(Currency::class, $currencyId);
         if (is_null($currency)) {
             $currency = $this->getBaseCurrency();
         }
 
-        return new PriceContext($price, $taxRate, $isNetPrice, $currency->getFactor());
+        return new PriceContext($price, $taxRate, $taxFree, $isNetPrice, $currency->getFactor());
     }
 
     /**

--- a/Components/PriceCalculation/Hydrator/RequestHydrator.php
+++ b/Components/PriceCalculation/Hydrator/RequestHydrator.php
@@ -38,6 +38,7 @@ class RequestHydrator
         $requestStruct->setPreviousCurrencyId((int) $data['oldCurrencyId']);
 
         $requestStruct->setShippingCosts((float) $data['shippingCosts']);
+        $requestStruct->setShippingCostsNet((float) $data['shippingCostsNet']);
 
         if (!empty($requestStruct->getPositions())) {
             $basketTaxRates = $this->getBasketTaxRates($requestStruct->getPositions());

--- a/Components/PriceCalculation/Struct/RequestStruct.php
+++ b/Components/PriceCalculation/Struct/RequestStruct.php
@@ -48,6 +48,11 @@ class RequestStruct
     /**
      * @var float
      */
+    private $shippingCostsNet;
+
+    /**
+     * @var float
+     */
     private $previousShippingTaxRate;
 
     /**
@@ -178,6 +183,22 @@ class RequestStruct
     public function setShippingCosts($shippingCosts)
     {
         $this->shippingCosts = $shippingCosts;
+    }
+
+    /**
+     * @return float
+     */
+    public function getShippingCostsNet()
+    {
+        return $this->shippingCostsNet;
+    }
+
+    /**
+     * @param float $shippingCostsNet
+     */
+    public function setShippingCostsNet($shippingCostsNet)
+    {
+        $this->shippingCostsNet = $shippingCostsNet;
     }
 
     /**

--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -815,7 +815,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
         $total = $totalPriceResult->getTotal()->getRoundedGrossPrice();
         $taxSum = $totalPriceResult->getTaxAmount();
 
-        if ($requestStruct->isTaxFree() || $requestStruct->isDisplayNet()) {
+        if ($requestStruct->isDisplayNet()) {
             $productSum = $totalPriceResult->getSum()->getRoundedNetPrice();
         }
 

--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -924,6 +924,8 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
     private function getShippingPrice($requestStruct)
     {
         $dispatchTaxRate = $this->getDispatchTaxRate($requestStruct->getDispatchId(), $requestStruct->getBasketTaxRates());
+
+        // Get base/gross shipping costs (even if taxfree)
         $previousPriceContext = $this->getPriceContextFactory()->create(
             $requestStruct->getShippingCosts(),
             $dispatchTaxRate,
@@ -933,6 +935,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
         );
         $baseShippingPrice = $this->getShippingCalculator()->calculateBasePrice($previousPriceContext);
 
+        // Calculate actual gross & net shipping costs for order
         $currentPriceContext = $this->getPriceContextFactory()->create(
             $baseShippingPrice,
             $dispatchTaxRate,

--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -182,7 +182,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
             $currencyFactor = $currency->getFactor();
         }
 
-        $priceContext = new PriceContext((float) $result['price'], (float) $result['tax'], true, $currencyFactor);
+        $priceContext = new PriceContext((float) $result['price'], (float) $result['tax'], true, $requestStruct->isTaxFree(), $currencyFactor);
 
         $price = $this->getProductCalculator()->calculate($priceContext);
         $result['price'] = $price->getRoundedGrossPrice();
@@ -860,6 +860,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
             $position->price,
             $position->taxRate,
             $requestStruct->isPreviousDisplayNet(),
+            $requestStruct->isPreviousTaxFree(),
             $requestStruct->getPreviousCurrencyId()
         );
         $basePrice = $this->getProductCalculator()->calculateBasePrice($previousPriceContext);
@@ -868,6 +869,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
             $basePrice,
             $position->taxRate,
             true,
+            $requestStruct->isTaxFree(),
             $requestStruct->getCurrencyId()
         );
 
@@ -926,6 +928,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
             $requestStruct->getShippingCosts(),
             $requestStruct->getPreviousShippingTaxRate(),
             $requestStruct->isPreviousDisplayNet(),
+            $requestStruct->isPreviousTaxFree(),
             $requestStruct->getPreviousCurrencyId()
         );
         $baseShippingPrice = $this->getShippingCalculator()->calculateBasePrice($previousPriceContext);
@@ -934,6 +937,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
             $baseShippingPrice,
             $this->getDispatchTaxRate($requestStruct->getDispatchId(), $requestStruct->getBasketTaxRates()),
             $requestStruct->isDisplayNet(),
+            $requestStruct->isTaxFree(),
             $requestStruct->getCurrencyId()
         );
 

--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -816,7 +816,6 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
         $taxSum = $totalPriceResult->getTaxAmount();
 
         if ($requestStruct->isTaxFree() || $requestStruct->isDisplayNet()) {
-            $shippingCosts = $totalPriceResult->getShipping()->getRoundedNetPrice();
             $productSum = $totalPriceResult->getSum()->getRoundedNetPrice();
         }
 
@@ -924,9 +923,10 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
      */
     private function getShippingPrice($requestStruct)
     {
+        $dispatchTaxRate = $this->getDispatchTaxRate($requestStruct->getDispatchId(), $requestStruct->getBasketTaxRates());
         $previousPriceContext = $this->getPriceContextFactory()->create(
             $requestStruct->getShippingCosts(),
-            $requestStruct->getPreviousShippingTaxRate(),
+            $dispatchTaxRate,
             $requestStruct->isPreviousDisplayNet(),
             $requestStruct->isPreviousTaxFree(),
             $requestStruct->getPreviousCurrencyId()
@@ -935,7 +935,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
 
         $currentPriceContext = $this->getPriceContextFactory()->create(
             $baseShippingPrice,
-            $this->getDispatchTaxRate($requestStruct->getDispatchId(), $requestStruct->getBasketTaxRates()),
+            $dispatchTaxRate,
             $requestStruct->isDisplayNet(),
             $requestStruct->isTaxFree(),
             $requestStruct->getCurrencyId()

--- a/Resources/views/backend/swag_backend_order/view/main/total_costs_overview.js
+++ b/Resources/views/backend/swag_backend_order/view/main/total_costs_overview.js
@@ -153,12 +153,21 @@ Ext.define('Shopware.apps.SwagBackendOrder.view.main.TotalCostsOverview', {
             '{literal}<tpl for=".">',
             '<div style="padding-left: 10px; font-size: 13px; text-align: right;">',
             '<p>{sum} ' + me.currencySymbol + '</p>',
-            '<p>{shippingCosts} ' + me.currencySymbol + '</p>',
+            '<p>{shippingCosts:this.shippingCosts} ' + me.currencySymbol + '</p>',
             '<p><b>{total} ' + me.currencySymbol + '</b></p>',
             '<p>{totalWithoutTax} ' + me.currencySymbol + '</p>',
             '<p>{taxSum} ' + me.currencySymbol + '</p>',
             '</div>',
-            '</tpl>{/literal}'
+            '</tpl>{/literal}',
+            {
+                shippingCosts: function (shippingCosts) {
+                    if (me.displayNetCheckbox.getValue())
+                        // Show net shipping costs if net order
+                        return me.totalCostsModel.get('shippingCostsNet');
+
+                    return shippingCosts;
+                }
+            }
         );
 
         return me.totalCostsTempalte;

--- a/Tests/Functional/Controller/SwagBackendOrderTest.php
+++ b/Tests/Functional/Controller/SwagBackendOrderTest.php
@@ -54,12 +54,38 @@ class SwagBackendOrderTest extends Enlight_Components_Test_Controller_TestCase
         $this->assertTrue($this->View()->success);
         $this->assertEquals(50.41, $result['sum']);
 
-        $this->assertEquals(3.28, $result['shippingCosts']);
+        $this->assertEquals(3.90, $result['shippingCosts']);
         $this->assertEquals(3.28, $result['shippingCostsNet']);
 
         $this->assertEquals(10.20, $result['taxSum']);
 
         $this->assertEquals(63.89, $result['total']);
+        $this->assertEquals(53.69, $result['totalWithoutTax']);
+
+        $this->assertEquals(50.41, $result['positions'][0]->price);
+
+        $this->resetRequest();
+        $this->resetResponse();
+    }
+
+    /**
+     * @covers \Shopware_Controllers_Backend_SwagBackendOrder::calculateBasketAction()
+     */
+    public function testBasketCalculationWithChangedTaxfreeFlag()
+    {
+        $this->Request()->setParams($this->getDemoWithChangedTaxfreeFlag());
+        $this->dispatch('/backend/SwagBackendOrder/calculateBasket');
+        $result = $this->View()->getAssign('data');
+
+        $this->assertTrue($this->View()->success);
+        $this->assertEquals(50.41, $result['sum']);
+
+        $this->assertEquals(3.28, $result['shippingCosts']);
+        $this->assertEquals(3.28, $result['shippingCostsNet']);
+
+        $this->assertEquals(0, $result['taxSum']);
+
+        $this->assertEquals(53.69, $result['total']);
         $this->assertEquals(53.69, $result['totalWithoutTax']);
 
         $this->assertEquals(50.41, $result['positions'][0]->price);
@@ -160,13 +186,8 @@ class SwagBackendOrderTest extends Enlight_Components_Test_Controller_TestCase
             'shippingCostsNet' => 3.28,
             'displayNet' => 'false',
             'oldCurrencyId' => '1',
-            'newCurrencyId' => '2',
-            'dispatchId' => 9,
-            'taxFree' => 'false',
-            'previousDisplayNet' => 'false',
-            'previousTaxFree' => 'false',
-            'previousDispatchTaxRate' => '19'
-        ];
+            'newCurrencyId' => '2'
+        ] + $this->getDemoData();
     }
 
     /**
@@ -183,6 +204,26 @@ class SwagBackendOrderTest extends Enlight_Components_Test_Controller_TestCase
             'newCurrencyId' => '',
             'dispatchId' => 9,
             'taxFree' => 'false',
+            'previousDisplayNet' => 'false',
+            'previousTaxFree' => 'false',
+            'previousDispatchTaxRate' => '19'
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getDemoWithChangedTaxfreeFlag()
+    {
+        return [
+            'positions' => '[{"id":0,"create_backend_order_id":0,"mode":0,"articleId":2,"detailId":0,"articleNumber":"SW10002.1","articleName":"M\u00fcnsterl\u00e4nder Lagerkorn 32% 1,5 Liter","quantity":1,"statusId":0,"statusDescription":"","taxId":1,"taxRate":19,"taxDescription":"","inStock":-7,"price":"59.99","total":"59.99"}]',
+            'shippingCosts' => 3.90,
+            'shippingCostsNet' => 3.28,
+            'displayNet' => 'true',
+            'oldCurrencyId' => '',
+            'newCurrencyId' => '',
+            'dispatchId' => 9,
+            'taxFree' => 'true',
             'previousDisplayNet' => 'false',
             'previousTaxFree' => 'false',
             'previousDispatchTaxRate' => '19'

--- a/Tests/Functional/PriceCalculation/PriceContextFactoryTest.php
+++ b/Tests/Functional/PriceCalculation/PriceContextFactoryTest.php
@@ -27,10 +27,11 @@ class PriceContextFactoryTest extends \Enlight_Components_Test_TestCase
         $price = 59.99;
         $taxRate = 19.00;
         $isNet = false;
+        $taxFree = false;
         $currencyId = 2;
         $currency = $this->getModelManager()->find(Currency::class, $currencyId);
 
-        $priceContext = $this->SUT->create($price, $taxRate, $isNet, $currencyId);
+        $priceContext = $this->SUT->create($price, $taxRate, $isNet, $taxFree, $currencyId);
 
         $this->assertEquals($price, $priceContext->getPrice());
         $this->assertEquals($taxRate, $priceContext->getTaxRate());
@@ -47,9 +48,10 @@ class PriceContextFactoryTest extends \Enlight_Components_Test_TestCase
         $price = 'invalid price';
         $taxRate = 'invalid tax rate';
         $isNet = false;
+        $taxFree = false;
         $currencyId = 2;
 
-        $this->SUT->create($price, $taxRate, $isNet, $currencyId);
+        $this->SUT->create($price, $taxRate, $isNet, $taxFree, $currencyId);
     }
 
     /**
@@ -60,10 +62,11 @@ class PriceContextFactoryTest extends \Enlight_Components_Test_TestCase
         $price = 59.99;
         $taxRate = 19.00;
         $isNet = false;
+        $taxFree = false;
         $invalidCurrencyId = 123;
         $defaultCurrencyFactor = 1;
 
-        $priceContext = $this->SUT->create($price, $taxRate, $isNet, $invalidCurrencyId);
+        $priceContext = $this->SUT->create($price, $taxRate, $isNet, $taxFree, $invalidCurrencyId);
 
         $this->assertEquals($defaultCurrencyFactor, $priceContext->getCurrencyFactor());
     }

--- a/Tests/Functional/PriceCalculation/ProductPriceCalculatorTest.php
+++ b/Tests/Functional/PriceCalculation/ProductPriceCalculatorTest.php
@@ -34,7 +34,7 @@ class ProductPriceCalculatorTest extends TestCase
      */
     public function testCalculate()
     {
-        $context = new PriceContext(50.41, 19.00, true, 1.3625);
+        $context = new PriceContext(50.41, 19.00, true, false, 1.3625);
 
         $price = $this->SUT->calculate($context);
         $this->assertEquals(68.683624999999992, $price->getNet());
@@ -46,7 +46,7 @@ class ProductPriceCalculatorTest extends TestCase
      */
     public function testCalculateBasePrice()
     {
-        $context = new PriceContext(81.74, 19.00, false, 1.3625);
+        $context = new PriceContext(81.74, 19.00, false, false, 1.3625);
 
         $basePrice =  $this->SUT->calculateBasePrice($context);
         $this->assertEquals(50.414000462570343, $basePrice);

--- a/Tests/Functional/PriceCalculation/ShippingPriceCalculatorTest.php
+++ b/Tests/Functional/PriceCalculation/ShippingPriceCalculatorTest.php
@@ -41,9 +41,31 @@ class ShippingPriceCalculatorTest extends TestCase
     /**
      * @covers ShippingPriceCalculator::calculateBasePrice()
      */
+    public function testCalculateBasePriceNet()
+    {
+        $context = new PriceContext(5.31, 19.00, false, false, 1.3625);
+
+        $price = $this->SUT->calculateBasePrice($context);
+        $this->assertEquals(3.8972477064220179, $price);
+    }
+
+    /**
+     * @covers ShippingPriceCalculator::calculateBasePrice()
+     */
     public function testCalculateBasePrice()
     {
         $context = new PriceContext(5.31, 19.00, true, false, 1.3625);
+
+        $price = $this->SUT->calculateBasePrice($context);
+        $this->assertEquals(3.8972477064220179, $price);
+    }
+
+    /**
+     * @covers ShippingPriceCalculator::calculateBasePrice()
+     */
+    public function testCalculateBasePriceTaxfree()
+    {
+        $context = new PriceContext(4.47, 19.00, true, true, 1.3625);
 
         $price = $this->SUT->calculateBasePrice($context);
         $this->assertEquals(3.9040733944954122, $price);

--- a/Tests/Functional/PriceCalculation/ShippingPriceCalculatorTest.php
+++ b/Tests/Functional/PriceCalculation/ShippingPriceCalculatorTest.php
@@ -31,7 +31,7 @@ class ShippingPriceCalculatorTest extends TestCase
      */
     public function testCalculate()
     {
-        $context = new PriceContext(3.90, 19.00, false, 1.3625);
+        $context = new PriceContext(3.90, 19.00, false, false, 1.3625);
 
         $price = $this->SUT->calculate($context);
         $this->assertEquals(5.31375, $price->getGross());
@@ -43,7 +43,7 @@ class ShippingPriceCalculatorTest extends TestCase
      */
     public function testCalculateBasePrice()
     {
-        $context = new PriceContext(4.47, 19.00, true, 1.3625);
+        $context = new PriceContext(5.31, 19.00, true, false, 1.3625);
 
         $price = $this->SUT->calculateBasePrice($context);
         $this->assertEquals(3.9040733944954122, $price);


### PR DESCRIPTION
Before this PR orders created in net mode where inconsistent because the shipping costs where taxfree while net mode is only for displaying the tax differently on the document, not actually removing it.

See this example before this PR:
<img width="1104" alt="screenshot 2016-10-20 23 12 22" src="https://cloud.githubusercontent.com/assets/710188/19578974/93ce358e-971e-11e6-80a6-6c77ada5a755.png">
<img width="903" alt="screenshot 2016-10-20 23 14 46" src="https://cloud.githubusercontent.com/assets/710188/19579110/26063c9e-971f-11e6-9631-625744ed47ca.png">
Document with `63.27` instead of `63.89` from the invoice amount: [invoice.pdf](https://github.com/shopwareLabs/SwagBackendOrder/files/542971/20004.pdf)

After this PR the gross shipping costs are `3.90` for this order which fixes the inconsistency and puts the plugin in line with how the frontend creates net orders.
