### PR TITLE
Articles not found when details.additionText is null

### DIFF
--- a/Components/ProductRepository.php
+++ b/Components/ProductRepository.php
@@ -60,7 +60,7 @@ class ProductRepository
                         'articles.name',
                         $builder->expr()->concat(
                             $builder->expr()->literal(' '),
-                            'IFNULL(details.additionalText,'')'
+                            'IFNULL(details.additionalText,\'\')'
                         )
                     ),
                     $builder->expr()->literal($search)

--- a/Components/ProductRepository.php
+++ b/Components/ProductRepository.php
@@ -60,7 +60,7 @@ class ProductRepository
                         'articles.name',
                         $builder->expr()->concat(
                             $builder->expr()->literal(' '),
-                            'details.additionalText'
+                            'IFNULL(details.additionalText,'')'
                         )
                     ),
                     $builder->expr()->literal($search)


### PR DESCRIPTION
The result of the QueryBuilder did not involve articles where the additionalText is NULL.

Take look in Stack Overflow for small example.
https://stackoverflow.com/questions/1035819/concating-null-fields
