### PR TITLE
Configure mail confirmation within the backend order form

### DIFF
--- a/Components/Order/Hydrator/OrderHydrator.php
+++ b/Components/Order/Hydrator/OrderHydrator.php
@@ -27,6 +27,7 @@ class OrderHydrator
 
     /**
      * @param \Enlight_Controller_Request_Request $request
+     *
      * @return OrderStruct
      */
     public function hydrateFromRequest(\Enlight_Controller_Request_Request $request)
@@ -54,6 +55,7 @@ class OrderHydrator
 
         $orderStruct->setNetOrder((boolean) $data['displayNet']);
         $orderStruct->setTaxFree((boolean) $data['taxFree']);
+        $orderStruct->setSendMail((bool) $data['sendMail']);
 
         $orderStruct->setTotal((float) $data['total']);
         $orderStruct->setTotalWithoutTax((float) $data['totalWithoutTax']);

--- a/Components/Order/Struct/OrderStruct.php
+++ b/Components/Order/Struct/OrderStruct.php
@@ -71,9 +71,14 @@ class OrderStruct
     private $deviceType;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $netOrder;
+
+    /**
+     * @var bool
+     */
+    private $sendMail;
 
     /**
      * @var PositionStruct[]
@@ -277,7 +282,7 @@ class OrderStruct
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getNetOrder()
     {
@@ -285,11 +290,27 @@ class OrderStruct
     }
 
     /**
-     * @param boolean $netOrder
+     * @param bool $netOrder
      */
     public function setNetOrder($netOrder)
     {
         $this->netOrder = $netOrder;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getSendMail()
+    {
+        return $this->sendMail;
+    }
+
+    /**
+     * @param bool $sendMail
+     */
+    public function setSendMail($sendMail)
+    {
+        $this->sendMail = $sendMail;
     }
 
     /**
@@ -365,7 +386,7 @@ class OrderStruct
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isTaxFree()
     {
@@ -373,7 +394,7 @@ class OrderStruct
     }
 
     /**
-     * @param boolean $taxFree
+     * @param bool $taxFree
      */
     public function setTaxFree($taxFree)
     {

--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -104,7 +104,9 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
 
             $modelManager->getConnection()->commit();
 
-            $this->sendOrderConfirmationMail($order);
+            if ($orderStruct->getSendMail() == 1) {
+                $this->sendOrderConfirmationMail($order);
+            }
         } catch (InvalidOrderException $e) {
             $modelManager->getConnection()->rollBack();
 
@@ -347,6 +349,11 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
         $desktopTypes = $pluginConfig['desktopTypes'];
         $desktopTypes = explode(',', $desktopTypes);
         $validationMail = $pluginConfig['validationMail'];
+        $sendMail = $pluginConfig['sendMail'];
+        $sendMailConfigGlobal = $this->get('config')->get('sendOrderMail');
+        if($sendMailConfigGlobal == 0) {
+            $sendMail = $sendMailConfigGlobal;
+        }
 
         $config = [];
         $config['desktopTypes'] = [];
@@ -359,6 +366,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
         }
 
         $config['validationMail'] = $validationMail;
+        $config['sendMail'] = $sendMail;
 
         $total = count($config);
 

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -19,5 +19,25 @@
             <description lang="de">Hier kann angegeben werden über welchen Kommunikatoinskanal die Bestellung eingegagen ist. Zum Beispiel Telefon, Handy, Geschäft, ... \n Die Verschiedenen Typen werden durch ein Komma (,) getrennt.</description>
             <description lang="en">You can choose which communication channel are available. For example telephone, mobile phone, store, and so on.\n The different types are separated by a comma (,).</description>
         </element>
+
+        <element required="true" type="select">
+            <name>sendMail</name>
+            <label lang="de">Bestätigungsmail standardmäßig versenden?</label>
+            <label lang="en">Send confirmation mail as default?</label>
+            <description lang="de">Hier kann ausgewählt werden, ob standardmäßig Bestätigungsmails aus den Backendbestellungen versendet werden sollen.</description>
+            <description lang="en">This configuration is to decide whether to send confirmation mails from backend orders or not as default.</description>
+            <store>
+                <option>
+                    <value>1</value>
+                    <label lang="DE">Ja</label>
+                    <label lang="EN">Yes</label>
+                </option>
+                <option>
+                    <value>0</value>
+                    <label lang="DE">Nein</label>
+                    <label lang="EN">No</label>
+                </option>
+            </store>
+        </element>
     </elements>
 </config>

--- a/Resources/snippets/backend/swag_backend_order/view/costs_overview.ini
+++ b/Resources/snippets/backend/swag_backend_order/view/costs_overview.ini
@@ -6,6 +6,7 @@ swag_backend_order/costs_overview/total_without_tax = "Total without tax: "
 swag_backend_order/costs_overview/tax_sum = "Tax sum: "
 display_net = "Display net prices"
 tax_free = "Tax free"
+send_mail = "Send mail confirmation?"
 
 [de_DE]
 swag_backend_order/costs_overview/sum = "Summe: "
@@ -15,3 +16,4 @@ swag_backend_order/costs_overview/total_without_tax = "Gesamtsumme ohne MwSt: "
 swag_backend_order/costs_overview/tax_sum = "zzgl. Steuer: "
 display_net = "Nettopreise anzeigen"
 tax_free = "Steuerfrei"
+send_mail = "Bestätigungsmail versenden?"

--- a/Resources/views/backend/swag_backend_order/controller/main.js
+++ b/Resources/views/backend/swag_backend_order/controller/main.js
@@ -627,12 +627,7 @@ Ext.define('Shopware.apps.SwagBackendOrder.controller.Main', {
 
                 me.validationMail = pluginConfigObj.data.validationMail;
                 me.desktopTypes = pluginConfigObj.data.desktopTypes;
-                me.sendMail = pluginConfigObj.data.sendMail;
-                if (me.sendMail == 1) {
-                    me.orderModel.set('sendMail', 1);
-                    //Check sendMail Checkbox
-                    me.getTotalCostsOverview().sendMailCheckbox.setValue(true);
-                }
+
                 me.subApplication.getStore('DesktopTypes').loadData(me.desktopTypes, false);
             }
         });

--- a/Resources/views/backend/swag_backend_order/controller/main.js
+++ b/Resources/views/backend/swag_backend_order/controller/main.js
@@ -104,7 +104,8 @@ Ext.define('Shopware.apps.SwagBackendOrder.controller.Main', {
             'createbackendorder-totalcostsoverview': {
                 calculateBasket: me.onCalculateBasket,
                 changeDisplayNet: me.onChangeDisplayNet,
-                changeTaxFreeCheckbox: me.onChangeTaxFree
+                changeTaxFreeCheckbox: me.onChangeTaxFree,
+                changeSendMail: me.onChangeSendMail
             }
         });
 
@@ -626,7 +627,12 @@ Ext.define('Shopware.apps.SwagBackendOrder.controller.Main', {
 
                 me.validationMail = pluginConfigObj.data.validationMail;
                 me.desktopTypes = pluginConfigObj.data.desktopTypes;
-
+                me.sendMail = pluginConfigObj.data.sendMail;
+                if (me.sendMail == 1) {
+                    me.orderModel.set('sendMail', 1);
+                    //Check sendMail Checkbox
+                    me.getTotalCostsOverview().sendMailCheckbox.setValue(true);
+                }
                 me.subApplication.getStore('DesktopTypes').loadData(me.desktopTypes, false);
             }
         });
@@ -740,6 +746,15 @@ Ext.define('Shopware.apps.SwagBackendOrder.controller.Main', {
         var me = this;
         me.orderModel.set('displayNet', newValue);
         me.onCalculateBasket();
+    },
+
+    /**
+     * Is responsible for the mail send confirmation
+     *  @param { boolean } newValue
+     */
+    onChangeSendMail: function (newValue, oldValue) {
+        var me = this;
+        me.orderModel.set('sendMail', newValue);
     },
 
     /**

--- a/Resources/views/backend/swag_backend_order/model/create_backend_order.js
+++ b/Resources/views/backend/swag_backend_order/model/create_backend_order.js
@@ -29,6 +29,7 @@ Ext.define('Shopware.apps.SwagBackendOrder.model.CreateBackendOrder', {
         { name: 'currencyId', type: 'string' },
         { name: 'desktopType', type: 'string' },
         { name: 'displayNet', type: 'boolean' },
+        { name: 'sendMail', type: 'boolean'},
         { name: 'taxFree', type: 'boolean' }
     ],
 

--- a/Resources/views/backend/swag_backend_order/view/main/total_costs_overview.js
+++ b/Resources/views/backend/swag_backend_order/view/main/total_costs_overview.js
@@ -55,6 +55,10 @@ Ext.define('Shopware.apps.SwagBackendOrder.view.main.TotalCostsOverview', {
             me.fireEvent('changeDisplayNet', newValue, oldValue);
         });
 
+        me.sendMailCheckbox.on('change', function (checkbox, newValue, oldValue) {
+            me.fireEvent('changeSendMail', newValue, oldValue);
+        });
+
         me.taxFreeCheckbox.on('change', function (checkbox, newValue, oldValue) {
             me.displayNetCheckbox.setDisabled(newValue);
             me.fireEvent('changeTaxFreeCheckbox', newValue, oldValue);
@@ -253,6 +257,19 @@ Ext.define('Shopware.apps.SwagBackendOrder.view.main.TotalCostsOverview', {
         return me.displayNetCheckbox;
     },
 
+    createSendMailCheckbox: function () {
+        var me = this;
+
+        me.sendMailCheckbox = Ext.create('Ext.form.field.Checkbox', {
+            boxLabel: '{s name="send_mail"}{/s}',
+            inputValue: true,
+            uncheckedValue: false,
+            padding: '0 5 0 0'
+        });
+
+        return me.sendMailCheckbox;
+    },
+
     /**
      * @returns { Ext.container.Container }
      */
@@ -263,7 +280,8 @@ Ext.define('Shopware.apps.SwagBackendOrder.view.main.TotalCostsOverview', {
             layout: 'vbox',
             items: [
                 me.createDisplayNetCheckbox(),
-                me.createTaxFreeCheckbox()
+                me.createTaxFreeCheckbox(),
+                me.createSendMailCheckbox()
             ]
         });
     },

--- a/Resources/views/backend/swag_backend_order/view/main/total_costs_overview.js
+++ b/Resources/views/backend/swag_backend_order/view/main/total_costs_overview.js
@@ -43,6 +43,8 @@ Ext.define('Shopware.apps.SwagBackendOrder.view.main.TotalCostsOverview', {
     initComponent: function () {
         var me = this;
 
+        me.getPluginConfig();
+
         me.currencyStore = me.subApplication.getStore('Currency');
         me.items = [
             me.createTotalCostsOverviewContainer()
@@ -300,7 +302,27 @@ Ext.define('Shopware.apps.SwagBackendOrder.view.main.TotalCostsOverview', {
         });
 
         return me.taxFreeCheckbox;
-    }
+    },
+
+    /**
+     * reads the plugin configuration
+     */
+    getPluginConfig: function() {
+        var me = this;
+
+        Ext.Ajax.request({
+            url: '{url action=getPluginConfig}',
+            success: function(response) {
+                var pluginConfigObj = Ext.decode(response.responseText);
+
+                me.sendMail = pluginConfigObj.data.sendMail;
+                if (me.sendMail == 1) {
+                    me.orderModel.set('sendMail', 1);
+                    me.sendMailCheckbox.setValue(true);
+                }
+            }
+        });
+    },
 });
 //
 //{/block}

--- a/SwagBackendOrder.php
+++ b/SwagBackendOrder.php
@@ -11,6 +11,7 @@ namespace SwagBackendOrder;
 use Shopware\Components\Plugin;
 use Shopware\Components\Plugin\Context\UpdateContext;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Shopware\Components\Plugin\Context\ActivateContext;
 
 class SwagBackendOrder extends Plugin
 {
@@ -21,5 +22,26 @@ class SwagBackendOrder extends Plugin
     {
         $container->setParameter('swag_backend_orders.plugin_dir', $this->getPath());
         parent::build($container);
+    }
+
+
+    /**
+     * @param ActivateContext $context
+     */
+    public function activate(ActivateContext $context)
+    {
+
+        $shop = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop')->findOneBy(array('default' => true));
+        $pluginManager = Shopware()->Container()->get('shopware_plugininstaller.plugin_manager');
+        $plugin = $pluginManager->getPluginByName($this->getName());
+        $sendMailConfigGlobal = Shopware()->Config()->get('sendOrderMail');
+        if($sendMailConfigGlobal == 1) {
+            $pluginManager->saveConfigElement($plugin, 'sendMail', '1', $shop);
+        }
+        else {
+            $pluginManager->saveConfigElement($plugin, 'sendMail', '0', $shop);
+        }
+
+        parent::activate($context);
     }
 }


### PR DESCRIPTION
At the moment it is not possible to configure the behavior of the confirmation mails. Currently every new backend order will also send a confirmation mail.
This change applies one new checkbox at the bottom to decide whether send a confirmation mail or not.

<img width="1102" alt="shopware_image_two" src="https://user-images.githubusercontent.com/12447078/29162032-8731a866-7db8-11e7-9d50-ad3a86bcaa0c.png">

A new global configuration is available to decide which default value should be used.

<img width="1111" alt="shopware_image_one" src="https://user-images.githubusercontent.com/12447078/29162049-94ccaf02-7db8-11e7-9a23-38792fd9d70f.png">

During the acitivation of the plugin the global Shopware Configuration sendOrderMail is considered and set as a default value within the plugin. 
If the global value sendOrderMail changes in the future from true to false, the plugin backend plugin configuration will be always set to false. 