### PR TITLE
fixed mistakenly email validation

### DIFF
--- a/Resources/views/backend/customer/view/create_backend_order/detail/base.js
+++ b/Resources/views/backend/customer/view/create_backend_order/detail/base.js
@@ -34,14 +34,12 @@ Ext.define('Shopware.apps.CreateBackendOrder.view.Base', {
                 listeners: {
                     scope: me,
                     afterrender: function (field) {
-                        setTimeout(function(){
+                        window.setTimeout(function () {
                             // only validates the email field if the mail is not the guest account email which can be configured in the plugin config
                             if (field.getValue() != me.record.get('email')) {
-                                window.setTimeout(function () {
-                                    field.validationUrl = '{url action="validateEmail"}';
-                                }, 500);
+                                field.validationUrl = '{url action="validateEmail"}';
                             }
-                        }, 0);
+                        }, 500);
                     }
                 }
             });

--- a/Resources/views/backend/customer/view/create_backend_order/detail/base.js
+++ b/Resources/views/backend/customer/view/create_backend_order/detail/base.js
@@ -34,12 +34,14 @@ Ext.define('Shopware.apps.CreateBackendOrder.view.Base', {
                 listeners: {
                     scope: me,
                     afterrender: function (field) {
-                        // only validates the email field if the mail is not the guest account email which can be configured in the plugin config
-                        if (field.getValue() != me.record.get('email')) {
-                            window.setTimeout(function () {
-                                field.validationUrl = '{url action="validateEmail"}';
-                            }, 500);
-                        }
+                        setTimeout(function(){
+                            // only validates the email field if the mail is not the guest account email which can be configured in the plugin config
+                            if (field.getValue() != me.record.get('email')) {
+                                window.setTimeout(function () {
+                                    field.validationUrl = '{url action="validateEmail"}';
+                                }, 500);
+                            }
+                        }, 0);
                     }
                 }
             });


### PR DESCRIPTION
Needed to wrap the afterrender event into a timeout due to the fact that field.getValue() may be empty and therefor the email validation takes place even if the automatically inserted guest email is equal to the configured guest email