### PR TITLE
Fix empty descriptions on outgoing mails

### DIFF
--- a/Components/Translation/ShippingTranslator.php
+++ b/Components/Translation/ShippingTranslator.php
@@ -48,7 +48,9 @@ class ShippingTranslator
             $shipping['dispatch_name'] = $shippingTranslations[$dispatchId]['dispatch_name'];
         }
 
-        $shipping['description'] = $shippingTranslations[$dispatchId]['description'];
+        if (!empty($shippingTranslations[$dispatchId]['description'])) {
+            $shipping['description'] = $shippingTranslations[$dispatchId]['description'];
+        }
 
         return $shipping;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
One of my customer talked to me about a missing description in outgoing mails from this plugin.
So I decided to check this for him.

### 2. What does this change do, exactly?
This PR fixes the empty description in outgoing mails. If the translation is empty, the description will be empty too, because it's overridden directly. I added an if with empty to check this.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new or edit an existing shipping provider in backend.
2. Modify the description and save it.
3. Open the backend order module and make a order with the modified shipping provider from above.
4. See the missing description in the order mail.

### 4. Please link to the relevant issues (if any).
Nothing.

### 5. Which documentation changes (if any) need to be made because of this PR?
Nothing.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.