### PR TITLE
Fix composer name to conform with composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "shopwareLabs/swag-backend-order",
+    "name": "shopwarelabs/swag-backend-order",
     "type": "shopware-plugin",
     "description": "Plugin which allows you to create orders via the backend orders module.",
     "license": "MIT",


### PR DESCRIPTION
`Deprecation warning: require.shopwareLabs/swag-backend-order is invalid, it should not contain uppercase characters. Please use shopwarelabs/swag-backend-order instead. Make sure you fix this as Composer 2.0 will error.`