### PR TITLE
Emit event for order processing hooks

### DIFF
--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -139,6 +139,12 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
 
             return;
         }
+        
+        $this->get('events')->notify('Shopware_Modules_Order_SaveOrder_OrderCreated', [
+            'subject' => $this,
+            'orderId' => $order->getId(),
+            'orderNumber' => $order->getNumber(),
+        ]);
 
         $this->view->assign([
             'success' => true,


### PR DESCRIPTION
We've developed a plugin that picks up every incoming order and sends it to an external API, which then processes the order. For this purpose, the plugin uses the event `Shopware_Modules_Order_SaveOrder_OrderCreated`, which was originally triggered by the core orders module.
Would be great if the BackendOrder plugin were compatible with it.