### PR TITLE
show net prices + discount

### DIFF
--- a/Components/PriceCalculation/Calculator/DiscountCalculator.php
+++ b/Components/PriceCalculation/Calculator/DiscountCalculator.php
@@ -44,11 +44,20 @@ class DiscountCalculator
     private function updateOrderDetails(&$orderData, &$discountPosition, $discount)
     {
         $taxRate = $discountPosition['taxRate'];
-        $discountNet = round($discount / (100 + $taxRate) * 100, 3);
-
+        
         //Update order amount
         $orderData['sum'] += $discount;
-        $orderData['total'] += $discount;
+        
+        //If showing net prices, discount is implied to be a net value.
+        //We will add taxes now so that the results are correct
+        if (!$orderData['isDisplayNet']) {
+          $orderData['total'] += $discount;
+          $discountNet = round($discount / (100 + $taxRate) * 100, 3);
+        } else {
+          $orderData['total'] += round( $discount * (1 + $taxRate / 100), 3);
+          $discountNet = $discount;
+        }
+        
 
         //If this is not a net order,
         //we have to calculate the tax value of the discount and add it to the order tax sum.

--- a/Controllers/Backend/SwagBackendOrder.php
+++ b/Controllers/Backend/SwagBackendOrder.php
@@ -496,6 +496,7 @@ class Shopware_Controllers_Backend_SwagBackendOrder extends Shopware_Controllers
         $totalPriceResult = $totalPriceCalculator->calculate($positionPrices, $dispatchPrice, $proportionalTaxCalculation);
         $result = $this->createBasketCalculationResult($totalPriceResult, $requestStruct, $proportionalTaxCalculation);
         $result['isTaxFree'] = $requestStruct->isTaxFree();
+        $result['isDisplayNet'] = $requestStruct->isDisplayNet();
 
         /** @var DiscountCalculator $discountCalculator */
         $discountCalculator = $this->get('swag_backend_order.price_calculation.discount_calculator');


### PR DESCRIPTION
https://issues.shopware.com/issues/PT-10672

When showing net prices, a discount is also automatically treated as having a (negative) net value.
Thus, we shouldn't substract the VAT once again.