### PR TITLE
fix calculation error for new orders on shopware 5.7.x

### DIFF
--- a/Components/Order/OrderService.php
+++ b/Components/Order/OrderService.php
@@ -67,6 +67,13 @@ class OrderService implements OrderServiceInterface
 
         $order = $this->orderFactory->create($orderStruct);
 
+        //Dirty fix for several Issues: (https://issues.shopware.com/issues/SW-25905, https://issues.shopware.com/issues/SW-26125, https://issues.shopware.com/issues/SW-26134)
+        //When calculation is not correct Shopware does not save the order correctly
+        //TODO: Rework
+        /** @var CalculationServiceInterface $service */
+        $service = Shopware()->Container()->get(\Shopware\Bundle\OrderBundle\Service\CalculationServiceInterface::class);
+        $service->recalculateOrderTotals($order);
+
         $this->modelManager->persist($order);
         foreach ($order->getPaymentInstances() as $instance) {
             $this->modelManager->persist($instance);


### PR DESCRIPTION
This Pullrequest provides a probably dirty fix for calculation errors that prevent shpware 5.7.x from saving an order.
There are several cases in the issuetracker that will work again with this fix.

https://issues.shopware.com/issues/SW-25905
https://issues.shopware.com/issues/SW-26125
https://issues.shopware.com/issues/SW-26134